### PR TITLE
remove unnecessary '#include <malloc.h>'

### DIFF
--- a/src/linalg/src/tc_mat.c
+++ b/src/linalg/src/tc_mat.c
@@ -4,11 +4,10 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.
  */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include <memory.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include "tc_mat.h"
 


### PR DESCRIPTION
The `malloc()` function is defined in `stdlib.h`, which is already included in `tc_mat.c`, so it shouldn't be necessary here. [`malloc.h` also won't be found on Mac OS X](https://code.google.com/archive/p/word2vec/issues/17) (without tinkering), so this fixes the build on OS X.
