### PR TITLE
Add Votecoin address RPC call, and update trade widget price display. 

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -364,6 +364,7 @@ static const CRPCCommand vRPCCommands[] =
     { "market",             "gettrade",               &gettrade,               false,     false,      true },
     { "market",             "getvote",                &getvote,                false,     false,      true },
     { "market",             "getballot",              &getballot,              false,     false,      true },
+    { "market",             "getnewvotecoinaddress",  &getnewvotecoinaddress,  false,     false,      true },
 
     { "market",             "createbranch",           &createbranch,           false,     false,      true },
     { "market",             "createdecision",         &createdecision,         false,     false,      true },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -240,6 +240,7 @@ extern json_spirit::Value getoutcome(const json_spirit::Array& params, bool fHel
 extern json_spirit::Value gettrade(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getvote(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getballot(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getnewvotecoinaddress(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value createbranch(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value createdecision(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -3663,6 +3663,49 @@ Value getballot(const Array &params, bool fHelp)
     return entry;
 }
 
+Value getnewvotecoinaddress(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "getnewvotecoinaddress ( \"account\" )\n"
+            "\nReturns a new Votecoin address\n"
+            "If 'account' is specified (recommended), it is added to the address book \n"
+            "so payments received with the address will be credited to 'account'.\n"
+            "\nArguments:\n"
+            "1. \"account\"         (string, optional) The account name for the address to be linked to.\n"
+            "\nResult:\n"
+            "\"votecoinaddress\"    (string) The new votecoin address\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getnewvotecoinaddress", "")
+            + HelpExampleCli("getnewvotecoinaddress", "\"\"")
+            + HelpExampleCli("getnewvotecoinaddress", "\"myaccount\"")
+            + HelpExampleRpc("getnewvotecoinaddress", "\"myaccount\"")
+        );
+
+    // Parse the account first so we don't generate a key if there's an error
+    string strAccount;
+    if (params.size() > 0)
+        strAccount = AccountFromValue(params[0]);
+
+    if (!pwalletMain->IsLocked())
+        pwalletMain->TopUpKeyPool();
+
+    // Generate a new key that is added to wallet
+    CPubKey newKey;
+    if (!pwalletMain->GetKeyFromPool(newKey))
+        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+    CKeyID keyID = newKey.GetID();
+
+    pwalletMain->SetAddressBook(keyID, strAccount, "receive");
+
+    // Create a Votecoin address from the new key
+    CHivemindAddress votecoinAddress;
+    votecoinAddress.is_votecoin = 1;
+    votecoinAddress.Set(keyID);
+
+    return votecoinAddress.ToString();
+}
+
 Value getcreatetradecapitalrequired(const Array& params, bool fHelp)
 {
     string strHelp =

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2759,6 +2759,8 @@ Value createtrade(const Array& params, bool fHelp)
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Hivemind address");
     address.GetKeyID(obj.keyID);
+
+    /* Add market id to the object, checked later (performance) */
     obj.marketid.SetHex(params[1].get_str());
 
     /* double-check buy_or_sell */
@@ -2847,10 +2849,8 @@ Value createtrade(const Array& params, bool fHelp)
 
     if ((obj.isBuy) && (1e-8*price > 1e-8*obj.price)) {
         delete market;
-        char tmp[32];
-        snprintf(tmp, sizeof(tmp), "%.8f", price);
         string strError = std::string("Error: price needs to be at least ")
-            + tmp;
+            + FormatMoney(price);
         throw JSONRPCError(RPC_WALLET_ERROR, strError.c_str());
     }
 


### PR DESCRIPTION
Using the new getnewvotecoinaddress RPC call is exactly the same as the regular getnewaddress call, but returns and address starting with V (Votecoin PUBKEY HASH) instead of 1 (Bitcoin PUBKEY HASH).

You may also run:
`help getnewvotecoinaddress`
in the RPC console to see the full help message.
