### PR TITLE
Fix QT backwards compatibility build issue, reported by gumbyclownshoes on hivemind slack.

### DIFF
--- a/buildall-nix.sh
+++ b/buildall-nix.sh
@@ -10,5 +10,5 @@ if  ! [[ -n "$threads" ]]; then
 fi
 
 ./autogen.sh
-./configure --with-incompatible-bdb
+./configure --with-incompatible-bdb --disable-tests
 make -j $threads

--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ AC_ARG_ENABLE([glibc-back-compat],
 
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
-# Enable debug 
+# Enable debug
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug],
                     [use debug compiler flags and macros (default is no)])],
@@ -157,11 +157,11 @@ if test "x$enable_debug" = xyes; then
     if test "x$GCC" = xyes; then
         CFLAGS="-g3 -O0 -DDEBUG"
     fi
-    
+
     if test "x$GXX" = xyes; then
         CXXFLAGS="-g3 -O0 -DDEBUG"
     fi
-fi 
+fi
 
 ## TODO: Remove these hard-coded paths and flags. They are here for the sake of
 ##       compatibility with the legacy buildsystem.
@@ -424,8 +424,8 @@ if test x$use_hardening != xno; then
 
   if test x$TARGET_OS != xwindows; then
     # All windows code is PIC, forcing it on just adds useless compile warnings
-    AX_CHECK_COMPILE_FLAG([-fPIE],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fPIE"])
-    AX_CHECK_LINK_FLAG([[-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"])
+    AX_CHECK_COMPILE_FLAG([-fPIC],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fPIC"])
+    AX_CHECK_LINK_FLAG([[-pic]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pic"])
   fi
 
   case $host in


### PR DESCRIPTION
Compile with -fPIC for backwards compatibility. Reported by gumbyclownshoes on hivemind slack.

This is a known issue upstream, and will be fixed when Hivemind is rebased with upstream. This is a temporary solution for users trying to build Hivemind-qt on recent linux distributions. 
