### PR TITLE
Change shebang executables to use /usr/bin/env

### DIFF
--- a/buildall-nix.sh
+++ b/buildall-nix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 threads=$1
 
 if  ! [[ -n "$threads" ]]; then

--- a/contrib/devtools/github-merge.sh
+++ b/contrib/devtools/github-merge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script will locally construct a merge commit for a pull request on a
 # github repository, inspect it, sign it and optionally push it.

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Wladimir J. van der Laan
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Wladimir J. van der Laan
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # linearize-data.py: Construct a linear, no-fork version of the chain.
 #

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # linearize-hashes.py:  List blocks in a linear, no-fork version of the chain.
 #

--- a/contrib/tidy_datadir.sh
+++ b/contrib/tidy_datadir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -d "$1" ]; then
   cd "$1"

--- a/contrib/verifysfbinaries/verify.sh
+++ b/contrib/verifysfbinaries/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###   This script attempts to download the signature file SHA256SUMS.asc from hivemind.org
 ###   It first checks if the signature passes, and then downloads the files specified in

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 CURDIR=$(cd $(dirname "$0"); pwd)

--- a/qa/pull-tester/run-hivemind-cli
+++ b/qa/pull-tester/run-hivemind-cli
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a thin wrapper around hivemind-cli that strips the Windows-style EOLs
 # from the output if present. It is necessary when using hivemind-cli.exe on

--- a/qa/pull-tester/run-hivemindd-for-test.sh.in
+++ b/qa/pull-tester/run-hivemindd-for-test.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2013-2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/qa/pull-tester/tests-config.sh.in
+++ b/qa/pull-tester/tests-config.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2013-2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/qa/rpc-tests/send.sh
+++ b/qa/rpc-tests/send.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/share/qt/make_windows_icon.sh
+++ b/share/qt/make_windows_icon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # create multiresolution windows icon
 ICON_SRC=../../src/qt/res/icons/hivemind.png
 ICON_DST=../../src/qt/res/icons/hivemind.ico

--- a/share/seeds/generate-seeds.py
+++ b/share/seeds/generate-seeds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Wladmir J. van der Laan
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/test/buildenv.py.in
+++ b/src/test/buildenv.py.in
@@ -1,2 +1,2 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 exeext="@EXEEXT@"

--- a/src/test/hivemind-util-test.py
+++ b/src/test/hivemind-util-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2014 BitPay, Inc.
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.


### PR DESCRIPTION
I had to change a couple of these to get things working on NixOS, so I've gone through and done it to all the scripts in the repo. NixOS doesn't keep executables under /bin or /usr/bin with the exception of sh and env. Using /usr/bin/env should be more portable.