### PR TITLE
Populate branch comboboxes using RPC

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -108,6 +108,7 @@ QT_MOC_CPP = \
   qt/moc_askpassphrasedialog.cpp \
   qt/moc_authorview.cpp \
   qt/moc_authorpendingtablemodel.cpp \
+  qt/moc_branchselect.cpp \
   qt/moc_hivemindaddressvalidator.cpp \
   qt/moc_hivemindamountfield.cpp \
   qt/moc_hivemindgui.cpp \
@@ -222,6 +223,7 @@ HIVEMIND_QT_H = \
   qt/askpassphrasedialog.h \
   qt/authorview.h \
   qt/authorpendingtablemodel.h \
+  qt/branchselect.h \
   qt/hivemindaddressvalidator.h \
   qt/hivemindamountfield.h \
   qt/hivemindgui.h \
@@ -296,6 +298,7 @@ HIVEMIND_QT_H = \
   qt/resolvevoterowtablemodel.h \
   qt/resolvevoteinputtablemodel.h \
   qt/rpcconsole.h \
+  qt/rpcwrapper.h \
   qt/scicon.h \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
@@ -405,6 +408,7 @@ HIVEMIND_QT_CPP += \
   qt/addressbookpage.cpp \
   qt/addresstablemodel.cpp \
   qt/askpassphrasedialog.cpp \
+  qt/branchselect.cpp \
   qt/coincontroldialog.cpp \
   qt/coincontroltreewidget.cpp \
   qt/combocreationwidget.cpp \
@@ -459,6 +463,7 @@ HIVEMIND_QT_CPP += \
   qt/resolvevotecoltablemodel.cpp \
   qt/resolvevoterowtablemodel.cpp \
   qt/resolvevoteinputtablemodel.cpp \
+  qt/rpcwrapper.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
   qt/signverifymessagedialog.cpp \

--- a/src/qt/branchselect.cpp
+++ b/src/qt/branchselect.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017 The Hivemind Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+#include "branchselect.h"
+#include "rpcwrapper.h"
+
+using namespace Ui;
+
+BranchSelect::BranchSelect(QWidget *parent):
+    QComboBox(parent)
+{
+    vector<RpcWrapper::BranchData> branches = RpcWrapper::listBranches();
+    for (size_t i = 0; i < branches.size(); i++) {
+        QComboBox::addItem(branches[i].name);
+        branchIds.push_back(branches[i].branchid);
+        branchIndexes[branches[i].branchid] = i;
+    }
+}
+
+BranchSelect::~BranchSelect() {
+}
+
+uint256 BranchSelect::currentId() {
+    int index = currentIndex();
+    uint256 ret;
+    if (index != -1) {
+        ret = branchIds[index];
+    }
+    return ret;
+}
+
+void BranchSelect::setCurrentId(const uint256 &id) {
+    map<uint256, size_t>::iterator it = branchIndexes.find(id);
+    if (it != branchIndexes.end()) {
+        setCurrentIndex(it->second);
+    }
+}
+

--- a/src/qt/branchselect.h
+++ b/src/qt/branchselect.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017 The Hivemind Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+#ifndef BRANCHSELECT_H
+#define BRANCHSELECT_H
+
+#include <vector>
+#include <QComboBox>
+#include "uint256.h"
+
+using namespace std;
+
+namespace Ui {
+class BranchSelect : public QComboBox
+{
+    Q_OBJECT
+
+public:
+    explicit BranchSelect(QWidget *parent = 0);
+    virtual ~BranchSelect();
+
+    uint256 currentId();
+    void setCurrentId(const uint256 &id);
+
+private:
+    vector<uint256> branchIds;
+    map<uint256, size_t> branchIndexes;
+};
+}
+
+#endif // BRANCHSELECT_H

--- a/src/qt/decisioncreationwidget.cpp
+++ b/src/qt/decisioncreationwidget.cpp
@@ -2,6 +2,7 @@
 #include "ui_decisioncreationwidget.h"
 
 #include <QMessageBox>
+#include "uint256.h"
 
 DecisionCreationWidget::DecisionCreationWidget(QWidget *parent) :
     QWidget(parent),
@@ -23,11 +24,7 @@ DecisionCreationWidget::~DecisionCreationWidget()
 
 json_spirit::Array DecisionCreationWidget::createDecisionArray()
 {
-    // Main branch ID
-    QString branchID;
-    if (ui->comboBoxBranch->currentText() == "Main") {
-        branchID = "0f894a25c5e0318ee148fe54600ebbf50782f0a1df1eb2aab06321a8ccec270d";
-    }
+    uint256 branchId = ui->branchSelect->currentId();
 
     // Grab user input from ui
     QString address = ui->lineEditOwnerAddr->text();
@@ -46,7 +43,7 @@ json_spirit::Array DecisionCreationWidget::createDecisionArray()
     bool error = false;
 
     // Perform basic checks and avoid wasting json calls
-    if (branchID.isEmpty()) {
+    if (branchId.IsNull()) {
         emit inputError("You must select a branch!");
         error = true;
     }
@@ -79,7 +76,7 @@ json_spirit::Array DecisionCreationWidget::createDecisionArray()
 
     // Add parameters to array
     params.push_back(address.toStdString());
-    params.push_back(branchID.toStdString());
+    params.push_back(branchId.ToString());
     params.push_back(prompt.toStdString());
     params.push_back(eventOverBy);
     params.push_back(answerOptionality);
@@ -153,13 +150,8 @@ void DecisionCreationWidget::editArray(json_spirit::Array array)
     branchLabel.append(branchID.left(12));
     branchLabel.append("...");
     ui->labelBranch->setText(branchLabel);
-    if (branchID == "0f894a25c5e0318ee148fe54600ebbf50782f0a1df1eb2aab06321a8ccec270d") {
-        ui->comboBoxBranch->setCurrentIndex(0); // Main
-    } else if (branchID == "419cd87761f45c108a976ca6d93d4929c7c4d1ff4386f5089fc2f7ff7ae21ddf") {
-        ui->comboBoxBranch->setCurrentIndex(1); // Sports
-    } else if (branchID == "3277b5057ac9cda54e9edfbb45fd8bab38be1b5afc3cd6c587f6d17779f34f74") {
-        ui->comboBoxBranch->setCurrentIndex(2); // Econ
-    }
+    uint256 uBranch = uint256S(branchID.toStdString());
+    ui->branchSelect->setCurrentId(uBranch);
 
     // Load prompt
     json_spirit::Value prompt = array.at(2);

--- a/src/qt/decisionmarketcreationwidget.cpp
+++ b/src/qt/decisionmarketcreationwidget.cpp
@@ -150,17 +150,7 @@ void DecisionMarketCreationWidget::on_pushButtonCreateMarket_clicked()
 void DecisionMarketCreationWidget::on_pushButtonSelectDecision_clicked()
 {
     // Grab the ID of the user selected branch
-    QString branchID;
-    if (ui->comboBoxBranch->currentText() == "Main") {
-        branchID = "0f894a25c5e0318ee148fe54600ebbf50782f0a1df1eb2aab06321a8ccec270d";
-    }
-
-    // Exit if no branch is selected (technically impossible via the UI)
-    if (branchID.isEmpty()) return;
-
-    // Grab the branch
-    uint256 uBranch;
-    uBranch.SetHex(branchID.toStdString());
+    uint256 uBranch = ui->branchSelect->currentId();
     const marketBranch *branch = pmarkettree->GetBranch(uBranch);
 
     if (!branch) return;

--- a/src/qt/forms/decisioncreationwidget.ui
+++ b/src/qt/forms/decisioncreationwidget.ui
@@ -39,18 +39,13 @@
         </property>
         <layout class="QGridLayout" name="gridLayout">
          <item row="1" column="0">
-          <widget class="QComboBox" name="comboBoxBranch">
+          <widget class="Ui::BranchSelect" name="branchSelect">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <item>
-            <property name="text">
-             <string>Main</string>
-            </property>
-           </item>
           </widget>
          </item>
          <item row="0" column="0">

--- a/src/qt/forms/decisionmarketcreationwidget.ui
+++ b/src/qt/forms/decisionmarketcreationwidget.ui
@@ -89,13 +89,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="comboBoxBranch">
-        <item>
-         <property name="text">
-          <string>Main</string>
-         </property>
-        </item>
-       </widget>
+       <widget class="Ui::BranchSelect" name="branchSelect" />
       </item>
       <item row="0" column="2" rowspan="2">
        <widget class="QPushButton" name="pushButtonSelectDecision">

--- a/src/qt/forms/voteview.ui
+++ b/src/qt/forms/voteview.ui
@@ -43,13 +43,7 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QComboBox" name="comboBoxBranch">
-           <item>
-            <property name="text">
-             <string>Main</string>
-            </property>
-           </item>
-          </widget>
+          <widget class="Ui::BranchSelect" name="branchSelect" />
          </item>
          <item row="0" column="2" rowspan="2">
           <widget class="QPushButton" name="pushButtonSelectDecision">

--- a/src/qt/rpcwrapper.cpp
+++ b/src/qt/rpcwrapper.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2017 The Hivemind Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+// Wrap RPC functions to implement packing/unpacking of JSON data.
+
+#include "rpcwrapper.h"
+
+#include <vector>
+#include <QString>
+#include <QMessageBox>
+
+#include "json/json_spirit.h"
+
+
+using namespace RpcWrapper;
+
+using namespace std;
+using namespace json_spirit;
+
+extern Value listbranches(const Array &params, bool fHelp);
+
+vector<BranchData> RpcWrapper::listBranches() {
+    QString error;
+    vector<BranchData> branches;
+
+
+    // TODO: return real data once rpc is up and working.
+
+    BranchData main;
+    main.name = "Main";
+    main.branchid = uint256S("0f894a25c5e0318ee148fe54600ebbf50782f0a1df1eb2aab06321a8ccec270d");
+    branches.push_back(main);
+    return branches;
+
+
+    try {
+        Value resp = listbranches(Array(), false);
+        if (resp.type() == array_type) {
+            Array branches_array = resp.get_array();
+            for (size_t i = 0; i < branches_array.size() && error.isEmpty(); i++) {
+                Value branch_value = branches_array[i];
+                if (branch_value.type() == obj_type) {
+                    Object branch_object = branch_value.get_obj();
+                    QString name;
+                    uint256 branchid;
+                    for (size_t j = 0; j < branch_object.size() && error.isEmpty(); j++) {
+                        if (branch_object[j].name_ == "name") {
+                            if (!name.isEmpty()) {
+                                error = "duplicate 'name' key in JSON data";
+                                break;
+                            }
+                            Value name_value = branch_object[j].value_;
+                            if (name_value.type() == str_type) {
+                                name = QString(name_value.get_str().c_str());
+                            } else {
+                                error = "Expected a string for 'name' key in JSON data";
+                                break;
+                            }
+                        }
+                        if (branch_object[j].name_ == "branchid") {
+                            if (!branchid.IsNull()) {
+                                error = "duplicate 'branchid' key in JSON data";
+                                break;
+                            }
+                            Value branchid_value = branch_object[j].value_;
+                            if (branchid_value.type() == str_type) {
+                                branchid.SetHex(branchid_value.get_str().c_str());
+                            } else {
+                                error = "Expected a string for 'name' key in JSON data";
+                                break;
+                            }
+                        }
+                    }
+                    if (name.isEmpty()) {
+                        error = "missing 'name' key in JSON data";
+                        break;
+                    }
+                    if (branchid.IsNull()) {
+                        error = "missing 'branchid' key in JSON data";
+                        break;
+                    }
+                    BranchData branch;
+                    branch.branchid = branchid;
+                    branch.name = name;
+                    branches.push_back(branch);
+                } else {
+                    error = "expected an object";
+                    break;
+                }
+            }
+        } else {
+            error = "expected an array";
+        }
+    } catch (const std::exception &e) {
+        error = e.what();
+    } catch (...) {
+        error = "unknown exception";
+    };
+
+    if (!error.isEmpty()) {
+        QMessageBox msgBox;
+        msgBox.setText("Failed to get list of branches");
+        msgBox.setInformativeText(error);
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.exec();
+        branches.clear();
+    }
+
+    return branches;
+}
+

--- a/src/qt/rpcwrapper.h
+++ b/src/qt/rpcwrapper.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2017 The Hivemind Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+// Wrap RPC functions to implement packing/unpacking of JSON data.
+
+#ifndef RPCWRAPPER_H
+#define RPCWRAPPER_H
+
+#include <vector>
+#include <QString>
+
+#include "uint256.h"
+
+using namespace std;
+
+namespace RpcWrapper {
+    struct BranchData {
+        uint256 branchid;
+        QString name;
+        // TODO fill in other fields
+    };
+
+    vector<BranchData> listBranches();
+}
+
+#endif // RPCWRAPPER_H

--- a/src/qt/voteview.cpp
+++ b/src/qt/voteview.cpp
@@ -249,18 +249,11 @@ void VoteView::on_pushButtonCreateSealedVote_clicked()
 
 void VoteView::selectDecision()
 {
-    // Grab the ID of the user selected branch
-    QString branchID;
-    if (ui->comboBoxBranch->currentText() == "Main") {
-        branchID = "0f894a25c5e0318ee148fe54600ebbf50782f0a1df1eb2aab06321a8ccec270d";
-    }
-
-    // Exit if no branch is selected (technically impossible via the UI)
-    if (branchID.isEmpty()) return;
-
     // Grab the branch
-    uint256 uBranch;
-    uBranch.SetHex(branchID.toStdString());
+    uint256 uBranch = ui->branchSelect->currentId();
+    if(uBranch.IsNull()) {
+        return;
+    }
     const marketBranch *branch = pmarkettree->GetBranch(uBranch);
 
     if (!branch) return;


### PR DESCRIPTION
Define a new widget, `BranchSelect` which is automatically populated with the list of branches obtained via RPC. Fixes #27.

I also started defining an `RpcWrapper` namespace whose job is to wrap the RPC methods, do the conversions to/from JSON, and report errors. This seems like it would be a good abstraction to have though it currently only wraps `listbranches`. For the sake of keeping things organised it would probably be a good idea to either move all the RPC calls into it, or just kill it (and move the `listbranches` stuff into `BranchSelect`). Thoughts?